### PR TITLE
Use separate Restic repositories for each Kubernetes namespace

### DIFF
--- a/ceph_backup/backup.py
+++ b/ceph_backup/backup.py
@@ -472,6 +472,7 @@ def backup_rbd_fs(api, vol, now, max_backup_duration):
     # Create a job to do the backup
     script = (
         'printf -- \'backing up filesystem %s/%s \\n\' ' + vol['namespace'] + ' ' + vol['name'] + ' >&2\n'
+        + 'if restic init >/dev/null 2>&1; then printf -- \'created new repository\\n\' >&2; fi\n'
         + 'stdbuf -o L -e L'
         + ' restic'
         + ' --exclude lost+found'
@@ -651,6 +652,7 @@ def backup_rbd_block(api, vol, now, max_backup_duration):
     # Create a job to do the backup
     script = (
         'printf -- \'backing up block %s/%s \\n\' ' + vol['namespace'] + ' ' + vol['name'] + ' >&2\n'
+        + 'if restic init >/dev/null 2>&1; then printf -- \'created new repository\\n\' >&2; fi\n'
         + 'rbd diff --whole-object --format=json ' + rbd_fq_image
         + ' > /tmp/layout.json'
         + ' && streaming-qcow2-writer /disk /tmp/layout.json'

--- a/ceph_backup/backup.py
+++ b/ceph_backup/backup.py
@@ -471,7 +471,8 @@ def backup_rbd_fs(api, vol, now, max_backup_duration):
 
     # Create a job to do the backup
     script = (
-        'printf -- \'backing up filesystem %s/%s \\n\' ' + vol['namespace'] + ' ' + vol['name'] + ' >&2\n'
+        'export RESTIC_REPOSITORY=$RESTIC_REPOSITORY_BASE/' + vol['namespace'] + '\n'
+        + 'printf -- \'backing up filesystem %s/%s \\n\' ' + vol['namespace'] + ' ' + vol['name'] + ' >&2\n'
         + 'if restic init >/dev/null 2>&1; then printf -- \'created new repository\\n\' >&2; fi\n'
         + 'stdbuf -o L -e L'
         + ' restic'
@@ -502,8 +503,8 @@ def backup_rbd_fs(api, vol, now, max_backup_duration):
                                 image_pull_policy=BACKUP_IMAGE_PULL_POLICY,
                                 args=['sh', '-c', script],
                                 env=format_env(
-                                    RESTIC_REPOSITORY=(
-                                        'secret', RESTIC_SECRET_NAME, 'url',
+                                    RESTIC_REPOSITORY_BASE=(
+                                        'secret', RESTIC_SECRET_NAME, 'base-url',
                                     ),
                                     RESTIC_HOST='rbd-fs-%s-nspvc-%s' % (
                                         vol['namespace'],
@@ -651,7 +652,8 @@ def backup_rbd_block(api, vol, now, max_backup_duration):
 
     # Create a job to do the backup
     script = (
-        'printf -- \'backing up block %s/%s \\n\' ' + vol['namespace'] + ' ' + vol['name'] + ' >&2\n'
+        'export RESTIC_REPOSITORY=$RESTIC_REPOSITORY_BASE/' + vol['namespace'] + '\n'
+        + 'printf -- \'backing up block %s/%s \\n\' ' + vol['namespace'] + ' ' + vol['name'] + ' >&2\n'
         + 'if restic init >/dev/null 2>&1; then printf -- \'created new repository\\n\' >&2; fi\n'
         + 'rbd diff --whole-object --format=json ' + rbd_fq_image
         + ' > /tmp/layout.json'
@@ -683,8 +685,8 @@ def backup_rbd_block(api, vol, now, max_backup_duration):
                                 image_pull_policy=BACKUP_IMAGE_PULL_POLICY,
                                 args=['sh', '-c', script],
                                 env=format_env(
-                                    RESTIC_REPOSITORY=(
-                                        'secret', RESTIC_SECRET_NAME, 'url',
+                                    RESTIC_REPOSITORY_BASE=(
+                                        'secret', RESTIC_SECRET_NAME, 'base-url',
                                     ),
                                     RESTIC_HOST='rbd-block-%s-nspvc-%s' % (
                                         vol['namespace'],

--- a/ceph_backup/backup.py
+++ b/ceph_backup/backup.py
@@ -474,7 +474,6 @@ def backup_rbd_fs(api, vol, now, max_backup_duration):
         'printf -- \'backing up filesystem %s/%s \\n\' ' + vol['namespace'] + ' ' + vol['name'] + ' >&2\n'
         + 'stdbuf -o L -e L'
         + ' restic'
-        + ' --host $(HOST)'
         + ' --exclude lost+found'
         + ' backup /data'
     )
@@ -505,7 +504,7 @@ def backup_rbd_fs(api, vol, now, max_backup_duration):
                                     RESTIC_REPOSITORY=(
                                         'secret', RESTIC_SECRET_NAME, 'url',
                                     ),
-                                    HOST='rbd-fs-%s-nspvc-%s' % (
+                                    RESTIC_HOST='rbd-fs-%s-nspvc-%s' % (
                                         vol['namespace'],
                                         vol['name'],
                                     ),
@@ -656,7 +655,6 @@ def backup_rbd_block(api, vol, now, max_backup_duration):
         + ' > /tmp/layout.json'
         + ' && streaming-qcow2-writer /disk /tmp/layout.json'
         + ' | stdbuf -o L -e L restic'
-        + ' --host $(HOST)'
         + ' backup --stdin --stdin-filename disk.qcow2'
     )
     with tracer.start_as_current_span('create-job'):
@@ -686,7 +684,7 @@ def backup_rbd_block(api, vol, now, max_backup_duration):
                                     RESTIC_REPOSITORY=(
                                         'secret', RESTIC_SECRET_NAME, 'url',
                                     ),
-                                    HOST='rbd-block-%s-nspvc-%s' % (
+                                    RESTIC_HOST='rbd-block-%s-nspvc-%s' % (
                                         vol['namespace'],
                                         vol['name'],
                                     ),

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,11 +38,14 @@ cephSecretName: ceph
 #     userKey: KP1BWrhRO2eTwG/tDf24N8SH5GCS1A5eIRfeNQ==
 cephKeySecretName: ceph-key
 
-# Secret containing 'url', the repository URL, and 'password', the repository password
+# Secret containing 'base-url', the base repository URL, and 'password', the
+# repository password
 # Example:
 #   stringData:
 #     url: rest:http://k8s-ceph:accesspassword@restic.example.com/k8s-ceph
 #     password: encryptpassword
+# This will create repositories for each namespace like:
+#   http://restic.example.com/k8s-ceph/some-namespace
 resticSecretName: restic
 
 # Every hour at 48 minutes past the hour


### PR DESCRIPTION
This should make loading the metadata for the repository faster, which should make the backup jobs start faster and use less RAM.